### PR TITLE
feature: call thunk and replace the call API then dispatch data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,35 +5,33 @@ import { Dialog } from './components/Dialog';
 import { login } from "./slices/userSlice";
 import { LOGIN_STATE } from './constants/local-storage';
 import { HomePage } from './pages/HomePage'
-import { loadData } from './slices/trendSlice';
-import { fetchLanguages, fetchTrends } from './data/trending';
-import { useAppDispatch, useAppSelector  } from "./redux";
-import { LoginStateType, TrendStateType } from './type';
-import { loadLanguages } from './slices/trendSlice';
+import { fetchLanguageData, fetchTrendData } from './slices/trendSlice';
+import { useAppDispatch, useAppSelector } from "./redux";
+import { LoginStateType } from './type';
 
 
 function App() {
   const dispatch = useAppDispatch();
   const dialog = useAppSelector((state) => state.dialog.open);
+  const lang = useAppSelector((state) => state.trend.langCode);
+  const range  = useAppSelector((state) => state.trend.rangeCode);
 
   useEffect(() => {
     const loginInfoString: string | null = localStorage.getItem(LOGIN_STATE)
-    if (loginInfoString){
+    if (loginInfoString) {
       const loginInfo: LoginStateType = JSON.parse(loginInfoString);
       dispatch(login(loginInfo));
     }
   }, [dispatch]);
 
   useEffect(() => {
-    const trendingData: TrendStateType[] = fetchTrends()
-    const languages: string[] = fetchLanguages()
-    dispatch(loadData(trendingData));
-    dispatch(loadLanguages(languages));
+    dispatch(fetchTrendData({lang, range}));
+    dispatch(fetchLanguageData());
   }, [dispatch])
 
   return (
     <div className="container">
-      {dialog && <Dialog /> }
+      { dialog && <Dialog /> }
         <Header />
         
         <HomePage />


### PR DESCRIPTION
Call thunk in `useEffect`, and replace the call API then dispatch data. through the thunk, it doesn't need to call API again and dispatch data to `trendSlice`, just call the thunk on `useEffect`, then the state will be updated via `extraReducers`.