### PR TITLE
fix: langName and rangeName computing logic in localStorage

### DIFF
--- a/src/middleware/localStorage.ts
+++ b/src/middleware/localStorage.ts
@@ -16,14 +16,14 @@ export const userMiddleware: Middleware<Record<string, unknown>, RootState> =
     if (selectLangCode.match(action)) {
       const languages = store.getState().trend.languages;
       const langCode = action.payload;
-      const langName = languages.find((item) => item.code === langCode)?.name;
+      const langName = languages.find((item) => item.code === langCode)?.name ?? "";
       const langState = { langCode, langName };
       localStorage.setItem(LANG_STATE, JSON.stringify(langState));
     }
     if (selectRangeCode.match(action)) {
       const dateRange = store.getState().trend.dateRange;
       const rangeCode = action.payload;
-      const rangeName = dateRange.find((item) => item.code === rangeCode)?.name;
+      const rangeName = dateRange.find((item) => item.code === rangeCode)?.name ?? "Daily";
       const rangeState = { rangeCode, rangeName };
       localStorage.setItem(RANGE_STATE, JSON.stringify(rangeState));
     }


### PR DESCRIPTION
1. fix the `langName` and `rangeName` computing logic in `localStorage`.